### PR TITLE
ItemGroup changes

### DIFF
--- a/src/main/java/io/github/sefiraat/emctech/slimefun/groups/EmcSlimefunDictionaryFlexGroup.java
+++ b/src/main/java/io/github/sefiraat/emctech/slimefun/groups/EmcSlimefunDictionaryFlexGroup.java
@@ -60,7 +60,7 @@ public class EmcSlimefunDictionaryFlexGroup extends FlexItemGroup {
 
     @Override
     @ParametersAreNonnullByDefault
-    public void open(Player player, PlayerProfile profile, SlimefunGuideMode mode) {
+    public void open(Player p, PlayerProfile profile, SlimefunGuideMode mode) {
         final ChestMenu chestMenu = new ChestMenu(Theme.MAIN.getColor() + "EMC Dictionary");
 
         for (int slot : HEADER) {
@@ -72,8 +72,9 @@ public class EmcSlimefunDictionaryFlexGroup extends FlexItemGroup {
         }
 
         chestMenu.setEmptySlotsClickable(false);
-        setupPage(player, profile, mode, chestMenu, 1);
-        chestMenu.open(player);
+        chestMenu.addMenuOpeningHandler((player) -> player.playSound(player.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1.0F, 1.0F));
+        setupPage(p, profile, mode, chestMenu, 1);
+        chestMenu.open(p);
     }
 
     @ParametersAreNonnullByDefault

--- a/src/main/java/io/github/sefiraat/emctech/slimefun/groups/EmcSlimefunDictionaryFlexGroup.java
+++ b/src/main/java/io/github/sefiraat/emctech/slimefun/groups/EmcSlimefunDictionaryFlexGroup.java
@@ -163,6 +163,7 @@ public class EmcSlimefunDictionaryFlexGroup extends FlexItemGroup {
             final int previousPage = page - 1;
             if (previousPage >= 1) {
                 setupPage(player1, profile, mode, menu, previousPage);
+                player1.playSound(player1.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1.0F, 1.0F);
             }
             return false;
         });
@@ -172,6 +173,7 @@ public class EmcSlimefunDictionaryFlexGroup extends FlexItemGroup {
             final int nextPage = page + 1;
             if (nextPage <= totalPages) {
                 setupPage(player1, profile, mode, menu, nextPage);
+                player1.playSound(player1.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1.0F, 1.0F);
             }
             return false;
         });

--- a/src/main/java/io/github/sefiraat/emctech/slimefun/groups/EmcSlimefunDictionaryFlexGroup.java
+++ b/src/main/java/io/github/sefiraat/emctech/slimefun/groups/EmcSlimefunDictionaryFlexGroup.java
@@ -17,6 +17,7 @@ import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -63,11 +64,11 @@ public class EmcSlimefunDictionaryFlexGroup extends FlexItemGroup {
         final ChestMenu chestMenu = new ChestMenu(Theme.MAIN.getColor() + "EMC Dictionary");
 
         for (int slot : HEADER) {
-            chestMenu.addItem(slot, ChestMenuUtils.getBackground(), (player1, i1, itemStack, clickAction) -> false);
+            chestMenu.addItem(slot, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
         }
 
         for (int slot : FOOTER) {
-            chestMenu.addItem(slot, ChestMenuUtils.getBackground(), (player1, i1, itemStack, clickAction) -> false);
+            chestMenu.addItem(slot, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
         }
 
         chestMenu.setEmptySlotsClickable(false);
@@ -111,7 +112,7 @@ public class EmcSlimefunDictionaryFlexGroup extends FlexItemGroup {
 
         // Stats
         menu.replaceExistingItem(GUIDE_STATS, getPlayerInfoStack(player, numberOfEntries));
-        menu.addMenuClickHandler(GUIDE_STATS, (player1, slot, itemStack, clickAction) -> false);
+        menu.addMenuClickHandler(GUIDE_STATS, ChestMenuUtils.getEmptyClickHandler());
 
         for (int i = 0; i < 36; i++) {
             final int slot = i + 9;
@@ -139,7 +140,7 @@ public class EmcSlimefunDictionaryFlexGroup extends FlexItemGroup {
             } else {
                 menu.replaceExistingItem(slot, null);
             }
-            menu.addMenuClickHandler(slot, (player1, i1, itemStack1, clickAction) -> false);
+            menu.addMenuClickHandler(slot, ChestMenuUtils.getEmptyClickHandler());
         }
     }
 
@@ -153,7 +154,7 @@ public class EmcSlimefunDictionaryFlexGroup extends FlexItemGroup {
     ) {
         for (int slot : FOOTER) {
             menu.replaceExistingItem(slot, ChestMenuUtils.getBackground());
-            menu.addMenuClickHandler(slot, ((player, i, itemStack, clickAction) -> false));
+            menu.addMenuClickHandler(slot, ChestMenuUtils.getEmptyClickHandler());
         }
 
         menu.replaceExistingItem(PAGE_PREVIOUS, ChestMenuUtils.getPreviousButton(p, page, totalPages));

--- a/src/main/java/io/github/sefiraat/emctech/slimefun/groups/EmcVanillaDictionaryFlexGroup.java
+++ b/src/main/java/io/github/sefiraat/emctech/slimefun/groups/EmcVanillaDictionaryFlexGroup.java
@@ -62,11 +62,11 @@ public class EmcVanillaDictionaryFlexGroup extends FlexItemGroup {
         final ChestMenu chestMenu = new ChestMenu(Theme.MAIN.getColor() + "EMC Dictionary");
 
         for (int slot : HEADER) {
-            chestMenu.addItem(slot, ChestMenuUtils.getBackground(), (player1, i1, itemStack, clickAction) -> false);
+            chestMenu.addItem(slot, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
         }
 
         for (int slot : FOOTER) {
-            chestMenu.addItem(slot, ChestMenuUtils.getBackground(), (player1, i1, itemStack, clickAction) -> false);
+            chestMenu.addItem(slot, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
         }
 
         chestMenu.setEmptySlotsClickable(false);
@@ -103,7 +103,7 @@ public class EmcVanillaDictionaryFlexGroup extends FlexItemGroup {
 
         // Stats
         menu.replaceExistingItem(GUIDE_STATS, getPlayerInfoStack(player, numberOfEntries));
-        menu.addMenuClickHandler(GUIDE_STATS, (player1, slot, itemStack, clickAction) -> false);
+        menu.addMenuClickHandler(GUIDE_STATS, ChestMenuUtils.getEmptyClickHandler());
 
         for (int i = 0; i < 36; i++) {
             final int slot = i + 9;
@@ -128,7 +128,7 @@ public class EmcVanillaDictionaryFlexGroup extends FlexItemGroup {
             } else {
                 menu.replaceExistingItem(slot, null);
             }
-            menu.addMenuClickHandler(slot, (player1, i1, itemStack1, clickAction) -> false);
+            menu.addMenuClickHandler(slot, ChestMenuUtils.getEmptyClickHandler());
         }
     }
 
@@ -142,7 +142,7 @@ public class EmcVanillaDictionaryFlexGroup extends FlexItemGroup {
     ) {
         for (int slot : FOOTER) {
             menu.replaceExistingItem(slot, ChestMenuUtils.getBackground());
-            menu.addMenuClickHandler(slot, ((player, i, itemStack, clickAction) -> false));
+            menu.addMenuClickHandler(slot, ChestMenuUtils.getEmptyClickHandler());
         }
 
         menu.replaceExistingItem(PAGE_PREVIOUS, ChestMenuUtils.getPreviousButton(p, page, totalPages));

--- a/src/main/java/io/github/sefiraat/emctech/slimefun/groups/EmcVanillaDictionaryFlexGroup.java
+++ b/src/main/java/io/github/sefiraat/emctech/slimefun/groups/EmcVanillaDictionaryFlexGroup.java
@@ -152,6 +152,7 @@ public class EmcVanillaDictionaryFlexGroup extends FlexItemGroup {
             final int previousPage = page - 1;
             if (previousPage >= 1) {
                 setupPage(player1, profile, mode, menu, previousPage);
+                player1.playSound(player1.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1.0F, 1.0F);
             }
             return false;
         });
@@ -161,6 +162,7 @@ public class EmcVanillaDictionaryFlexGroup extends FlexItemGroup {
             final int nextPage = page + 1;
             if (nextPage <= totalPages) {
                 setupPage(player1, profile, mode, menu, nextPage);
+                player1.playSound(player1.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1.0F, 1.0F);
             }
             return false;
         });

--- a/src/main/java/io/github/sefiraat/emctech/slimefun/groups/EmcVanillaDictionaryFlexGroup.java
+++ b/src/main/java/io/github/sefiraat/emctech/slimefun/groups/EmcVanillaDictionaryFlexGroup.java
@@ -16,6 +16,7 @@ import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -70,6 +71,7 @@ public class EmcVanillaDictionaryFlexGroup extends FlexItemGroup {
         }
 
         chestMenu.setEmptySlotsClickable(false);
+        chestMenu.addMenuOpeningHandler((player) -> player.playSound(player.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1.0F, 1.0F));
         setupPage(p, profile, mode, chestMenu, 1);
         chestMenu.open(p);
     }

--- a/src/main/java/io/github/sefiraat/emctech/slimefun/groups/MainFlexGroup.java
+++ b/src/main/java/io/github/sefiraat/emctech/slimefun/groups/MainFlexGroup.java
@@ -53,11 +53,11 @@ public class MainFlexGroup extends FlexItemGroup {
         final ChestMenu chestMenu = new ChestMenu(Theme.MAIN.getColor() + "EMC Tech");
 
         for (int slot : HEADER) {
-            chestMenu.addItem(slot, ChestMenuUtils.getBackground(), (player1, i1, itemStack, clickAction) -> false);
+            chestMenu.addItem(slot, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
         }
 
         for (int slot : FOOTER) {
-            chestMenu.addItem(slot, ChestMenuUtils.getBackground(), (player1, i1, itemStack, clickAction) -> false);
+            chestMenu.addItem(slot, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
         }
 
         chestMenu.setEmptySlotsClickable(false);
@@ -70,7 +70,7 @@ public class MainFlexGroup extends FlexItemGroup {
     private void setupPage(Player player, PlayerProfile profile, SlimefunGuideMode mode, ChestMenu menu) {
         for (int slot : FOOTER) {
             menu.replaceExistingItem(slot, ChestMenuUtils.getBackground());
-            menu.addMenuClickHandler(slot, ((player1, i, itemStack, clickAction) -> false));
+            menu.addMenuClickHandler(slot, ChestMenuUtils.getEmptyClickHandler());
         }
 
         // Back

--- a/src/main/java/io/github/sefiraat/emctech/slimefun/groups/MainFlexGroup.java
+++ b/src/main/java/io/github/sefiraat/emctech/slimefun/groups/MainFlexGroup.java
@@ -10,6 +10,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -60,6 +61,7 @@ public class MainFlexGroup extends FlexItemGroup {
         }
 
         chestMenu.setEmptySlotsClickable(false);
+        chestMenu.addMenuOpeningHandler((player) -> player.playSound(p.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1.0F, 1.0F));
         setupPage(p, profile, mode, chestMenu);
         chestMenu.open(p);
     }


### PR DESCRIPTION
- Add sound for ItemGroups (same as other Slimefun ItemGroup)
- Use `ChestMenuUtils.getEmptyClickHandler()` to replace all empty handlers `(p, slot, itemStack, clickAction) -> false`.
- Change back button's lore to match slimefun core's back buttons